### PR TITLE
Make WaitForNextRender method asynchronous

### DIFF
--- a/src/Components/Fixture.cs
+++ b/src/Components/Fixture.cs
@@ -31,7 +31,7 @@ namespace Egil.RazorComponents.Testing
         [Parameter] public Action Setup { get => _setup; set => _setup = value ?? NoopTestMethod; }
 
         /// <summary>
-        /// Gets or sets the setup asynchronous action to perform before the <see cref="Test"/> action,
+        /// Gets or sets the asynchronous setup action to perform before the <see cref="Test"/> action,
         /// <see cref="TestAsync"/> action and <see cref="Tests"/> and <see cref="TestsAsync"/> actions are invoked.
         /// </summary>
         [Parameter] public Func<Task> SetupAsync { get => _setupAsync; set => _setupAsync = value ?? NoopAsyncTestMethod; }

--- a/src/Components/Fixture.cs
+++ b/src/Components/Fixture.cs
@@ -13,11 +13,11 @@ namespace Egil.RazorComponents.Testing
     public class Fixture : FragmentBase
     {
         private Action _setup = NoopTestMethod;
-        private Func<Task> _asyncSetup = NoopAsyncTestMethod;
+        private Func<Task> _setupAsync = NoopAsyncTestMethod;
         private Action _test = NoopTestMethod;
-        private Func<Task> _asyncTest = NoopAsyncTestMethod;
+        private Func<Task> _testAsync = NoopAsyncTestMethod;
         private IReadOnlyCollection<Action> _tests = Array.Empty<Action>();
-        private IReadOnlyCollection<Func<Task>> _asyncTests = Array.Empty<Func<Task>>();
+        private IReadOnlyCollection<Func<Task>> _testsAsync = Array.Empty<Func<Task>>();
 
         /// <summary>
         /// A description or name for the test that will be displayed if the test fails.
@@ -26,15 +26,15 @@ namespace Egil.RazorComponents.Testing
 
         /// <summary>
         /// Gets or sets the setup action to perform before the <see cref="Test"/> action,
-        /// <see cref="AsyncTest"/> action and <see cref="Tests"/> and <see cref="AsyncTests"/> actions are invoked.
+        /// <see cref="TestAsync"/> action and <see cref="Tests"/> and <see cref="TestsAsync"/> actions are invoked.
         /// </summary>
         [Parameter] public Action Setup { get => _setup; set => _setup = value ?? NoopTestMethod; }
 
         /// <summary>
         /// Gets or sets the setup asynchronous action to perform before the <see cref="Test"/> action,
-        /// <see cref="AsyncTest"/> action and <see cref="Tests"/> and <see cref="AsyncTests"/> actions are invoked.
+        /// <see cref="TestAsync"/> action and <see cref="Tests"/> and <see cref="TestsAsync"/> actions are invoked.
         /// </summary>
-        [Parameter] public Func<Task> AsyncSetup { get => _asyncSetup; set => _asyncSetup = value ?? NoopAsyncTestMethod; }
+        [Parameter] public Func<Task> SetupAsync { get => _setupAsync; set => _setupAsync = value ?? NoopAsyncTestMethod; }
 
         /// <summary>
         /// Gets or sets the first test action to invoke, after the <see cref="Setup"/> action has
@@ -46,13 +46,13 @@ namespace Egil.RazorComponents.Testing
         [Parameter] public Action Test { get => _test; set => _test = value ?? NoopTestMethod; }
 
         /// <summary>
-        /// Gets or sets the first test action to invoke, after the <see cref="AsyncSetup"/> action has
+        /// Gets or sets the first test action to invoke, after the <see cref="SetupAsync"/> action has
         /// executed (if provided).
         /// 
         /// Use this to assert against the <see cref="ComponentUnderTest"/> and <see cref="Fragment"/>'s
         /// defined in the <see cref="Fixture"/>.
         /// </summary>
-        [Parameter] public Func<Task> AsyncTest { get => _asyncTest; set => _asyncTest = value ?? NoopAsyncTestMethod; }
+        [Parameter] public Func<Task> TestAsync { get => _testAsync; set => _testAsync = value ?? NoopAsyncTestMethod; }
 
         /// <summary>
         /// Gets or sets the test actions to invoke, one at the time, in the order they are placed 
@@ -66,13 +66,13 @@ namespace Egil.RazorComponents.Testing
 
         /// <summary>
         /// Gets or sets the test actions to invoke, one at the time, in the order they are placed 
-        /// into the collection, after the <see cref="AsyncSetup"/> action and the <see cref="AsyncTest"/> action has
+        /// into the collection, after the <see cref="SetupAsync"/> action and the <see cref="TestAsync"/> action has
         /// executed (if provided).
         /// 
         /// Use this to assert against the <see cref="ComponentUnderTest"/> and <see cref="Fragment"/>'s
         /// defined in the <see cref="Fixture"/>.
         /// </summary>
-        [Parameter] public IReadOnlyCollection<Func<Task>> AsyncTests { get => _asyncTests; set => _asyncTests = value ?? Array.Empty<Func<Task>>(); }
+        [Parameter] public IReadOnlyCollection<Func<Task>> TestsAsync { get => _testsAsync; set => _testsAsync = value ?? Array.Empty<Func<Task>>(); }
 
         private static void NoopTestMethod() { }
 

--- a/src/Components/Fixture.cs
+++ b/src/Components/Fixture.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Threading.Tasks;
 using Microsoft.AspNetCore.Components;
 
 namespace Egil.RazorComponents.Testing
@@ -12,8 +13,11 @@ namespace Egil.RazorComponents.Testing
     public class Fixture : FragmentBase
     {
         private Action _setup = NoopTestMethod;
+        private Func<Task> _asyncSetup = NoopAsyncTestMethod;
         private Action _test = NoopTestMethod;
+        private Func<Task> _asyncTest = NoopAsyncTestMethod;
         private IReadOnlyCollection<Action> _tests = Array.Empty<Action>();
+        private IReadOnlyCollection<Func<Task>> _asyncTests = Array.Empty<Func<Task>>();
 
         /// <summary>
         /// A description or name for the test that will be displayed if the test fails.
@@ -21,10 +25,16 @@ namespace Egil.RazorComponents.Testing
         [Parameter] public string? Description { get; set; }
 
         /// <summary>
-        /// Gets or sets the setup action to perform before the <see cref="Test"/> action
-        /// and <see cref="Tests"/> actions are invoked.
+        /// Gets or sets the setup action to perform before the <see cref="Test"/> action,
+        /// <see cref="AsyncTest"/> action and <see cref="Tests"/> and <see cref="AsyncTests"/> actions are invoked.
         /// </summary>
         [Parameter] public Action Setup { get => _setup; set => _setup = value ?? NoopTestMethod; }
+
+        /// <summary>
+        /// Gets or sets the setup asynchronous action to perform before the <see cref="Test"/> action,
+        /// <see cref="AsyncTest"/> action and <see cref="Tests"/> and <see cref="AsyncTests"/> actions are invoked.
+        /// </summary>
+        [Parameter] public Func<Task> AsyncSetup { get => _asyncSetup; set => _asyncSetup = value ?? NoopAsyncTestMethod; }
 
         /// <summary>
         /// Gets or sets the first test action to invoke, after the <see cref="Setup"/> action has
@@ -36,6 +46,15 @@ namespace Egil.RazorComponents.Testing
         [Parameter] public Action Test { get => _test; set => _test = value ?? NoopTestMethod; }
 
         /// <summary>
+        /// Gets or sets the first test action to invoke, after the <see cref="AsyncSetup"/> action has
+        /// executed (if provided).
+        /// 
+        /// Use this to assert against the <see cref="ComponentUnderTest"/> and <see cref="Fragment"/>'s
+        /// defined in the <see cref="Fixture"/>.
+        /// </summary>
+        [Parameter] public Func<Task> AsyncTest { get => _asyncTest; set => _asyncTest = value ?? NoopAsyncTestMethod; }
+
+        /// <summary>
         /// Gets or sets the test actions to invoke, one at the time, in the order they are placed 
         /// into the collection, after the <see cref="Setup"/> action and the <see cref="Test"/> action has
         /// executed (if provided).
@@ -45,6 +64,18 @@ namespace Egil.RazorComponents.Testing
         /// </summary>
         [Parameter] public IReadOnlyCollection<Action> Tests { get => _tests; set => _tests = value ?? Array.Empty<Action>(); }
 
+        /// <summary>
+        /// Gets or sets the test actions to invoke, one at the time, in the order they are placed 
+        /// into the collection, after the <see cref="AsyncSetup"/> action and the <see cref="AsyncTest"/> action has
+        /// executed (if provided).
+        /// 
+        /// Use this to assert against the <see cref="ComponentUnderTest"/> and <see cref="Fragment"/>'s
+        /// defined in the <see cref="Fixture"/>.
+        /// </summary>
+        [Parameter] public IReadOnlyCollection<Func<Task>> AsyncTests { get => _asyncTests; set => _asyncTests = value ?? Array.Empty<Func<Task>>(); }
+
         private static void NoopTestMethod() { }
+
+        private static Task NoopAsyncTestMethod() => Task.CompletedTask;
     }
 }

--- a/src/Components/TestComponentBase.cs
+++ b/src/Components/TestComponentBase.cs
@@ -103,16 +103,16 @@ namespace Egil.RazorComponents.Testing
                 _testContextAdapter.ActivateRazorTestContext(testData);
                 
                 InvokeFixtureAction(fixture, fixture.Setup);
-                await InvokeFixtureAction(fixture, fixture.AsyncSetup).ConfigureAwait(false);
+                await InvokeFixtureAction(fixture, fixture.SetupAsync).ConfigureAwait(false);
                 InvokeFixtureAction(fixture, fixture.Test);
-                await InvokeFixtureAction(fixture, fixture.AsyncTest).ConfigureAwait(false);
+                await InvokeFixtureAction(fixture, fixture.TestAsync).ConfigureAwait(false);
 
                 foreach (var test in fixture.Tests)
                 {
                     InvokeFixtureAction(fixture, test);
                 }
 
-                foreach (var test in fixture.AsyncTests)
+                foreach (var test in fixture.TestsAsync)
                 {
                     await InvokeFixtureAction(fixture, test).ConfigureAwait(false);
                 }

--- a/src/Components/TestComponentBase.cs
+++ b/src/Components/TestComponentBase.cs
@@ -2,6 +2,7 @@
 using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Text;
+using System.Threading.Tasks;
 using Egil.RazorComponents.Testing.Asserting;
 using Egil.RazorComponents.Testing.Diffing;
 using Microsoft.AspNetCore.Components;
@@ -52,12 +53,12 @@ namespace Egil.RazorComponents.Testing
         /// in the file and runs their associated tests.
         /// </summary>
         [Fact(DisplayName = "Razor test runner")]
-        public void RazorTest()
+        public async Task RazorTest()
         {
             var container = new ContainerComponent(_renderer.Value);
             container.Render(BuildRenderTree);
 
-            ExecuteFixtureTests(container);
+            await ExecuteFixtureTests(container).ConfigureAwait(false);
             ExecuteSnapshotTests(container);
         }
 
@@ -92,7 +93,7 @@ namespace Egil.RazorComponents.Testing
                 base.WaitForNextRender(renderTrigger, timeout);
         }
 
-        private void ExecuteFixtureTests(ContainerComponent container)
+        private async Task ExecuteFixtureTests(ContainerComponent container)
         {
             foreach (var (_, fixture) in container.GetComponents<Fixture>())
             {
@@ -102,11 +103,18 @@ namespace Egil.RazorComponents.Testing
                 _testContextAdapter.ActivateRazorTestContext(testData);
                 
                 InvokeFixtureAction(fixture, fixture.Setup);
+                await InvokeFixtureAction(fixture, fixture.AsyncSetup).ConfigureAwait(false);
                 InvokeFixtureAction(fixture, fixture.Test);
+                await InvokeFixtureAction(fixture, fixture.AsyncTest).ConfigureAwait(false);
 
                 foreach (var test in fixture.Tests)
                 {
                     InvokeFixtureAction(fixture, test);
+                }
+
+                foreach (var test in fixture.AsyncTests)
+                {
+                    await InvokeFixtureAction(fixture, test).ConfigureAwait(false);
                 }
 
                 _testContextAdapter.DisposeActiveTestContext();
@@ -118,6 +126,18 @@ namespace Egil.RazorComponents.Testing
             try
             {
                 action();
+            }
+            catch (Exception ex)
+            {
+                throw new FixtureFailedException(fixture.Description ?? $"{action.Method.Name} failed:", ex);
+            }
+        }
+
+        private static async Task InvokeFixtureAction(Fixture fixture, Func<Task> action)
+        {
+            try
+            {
+                await action().ConfigureAwait(false);
             }
             catch (Exception ex)
             {


### PR DESCRIPTION
* Make WaitForNextRender asynchronous, instead of blocking until NextRender Task is completed. Blocking on task may lead to deadlocks.
* Add support for asynchronous tests in Fixture so that WaitForNextRender can be called properly.